### PR TITLE
Change alpha to beta

### DIFF
--- a/overview.mdx
+++ b/overview.mdx
@@ -30,7 +30,7 @@ Example workloads/reasons to use Ubicloud today include:
 Our GitHub repo is here: [https://github.com/ubicloud/ubicloud](https://github.com/ubicloud/ubicloud) available to use for free under the GNU Affero General Public License version 3 (AGPL v3).
 
 ## Product
-Ubicloud is in public alpha. You can provide us with feedback, get help, or ask us to support your bare metal provider by sending us an email at [support@ubicloud.com](mailto:support@ubicloud.com)
+Ubicloud is in public beta. You can provide us with feedback, get help, or ask us to support your bare metal provider by sending us an email at [support@ubicloud.com](mailto:support@ubicloud.com)
 
 ‍Existing cloud services and additional components include the following:
   - Elastic Compute - Provision, use, and delete isolated VMs on bare metal


### PR DESCRIPTION
We use the term "public beta" in the description for the GitHub repository, and this should match.