### PR TITLE
Fix Logo link and Support

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -3,7 +3,8 @@
   "name": "Ubicloud Documentation",
   "logo": {
     "dark": "/logo/dark.svg",
-    "light": "/logo/light.svg"
+    "light": "/logo/light.svg",
+    "href": "https://www.ubicloud.com/"
   },
   "favicon": "/favicon.png",
   "colors": {
@@ -27,7 +28,7 @@
   "topbarLinks": [
     {
       "name": "Support",
-      "url": "about/support"
+      "url": "/about/support"
     },
     {
       "name": "Sign In",


### PR DESCRIPTION
The Ubicloud Logo at the top left redirected to ubicloud.com/docs, but we want it to redirect to the Ubicloud main page.

Also, the support link at the top didn't work, so I hardcoded the link for it.