### PR TITLE
Enable Matomo Analytics for documentation

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,30 @@
+if (location.hostname == "localhost") {
+  console.log("Analytics disabled on localhost");
+} else {
+  // Tracking code provided by Matomo Analytics
+  var _paq = (window._paq = window._paq || []);
+  _paq.push(["trackPageView"]);
+  _paq.push(["enableLinkTracking"]);
+  (function () {
+    var u = "https://ubicloud.matomo.cloud/";
+    _paq.push(["setTrackerUrl", u + "matomo.php"]);
+    _paq.push(["setSiteId", "1"]);
+    var d = document,
+      g = d.createElement("script"),
+      s = d.getElementsByTagName("script")[0];
+    g.async = true;
+    g.src = "https://cdn.matomo.cloud/ubicloud.matomo.cloud/matomo.js";
+    s.parentNode.insertBefore(g, s);
+  })();
+
+  // Since it's a SPA, track page views on title change
+  var target = document.querySelector("title");
+  var observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      _paq.push(["setCustomUrl", window.location.href]);
+      _paq.push(["setDocumentTitle", document.title]);
+      _paq.push(["trackPageView"]);
+    });
+  });
+  observer.observe(target, { childList: true });
+}


### PR DESCRIPTION
To comply with GDPR, we use Matomo Analytics instead of Google Analytics. Our website is built on Webflow, which has native Matomo integration. However, since our documentation is hosted on Mintlify, we need to add Matomo manually.

Enabling Matomo Analytics for server-side pages is straightforward; you just need to add the tracking JavaScript code. However, since our documentation is a single-page application, it doesn't load the script every time you navigate to a new page.

Matomo provides a guide for SPA tracking: https://developer.matomo.org/guides/spa-tracking

I tried various methods to make it work, but `window.navigation.addEventListener("navigate", ...)`, `history.onpushstate`, `window.addEventListener('locationchange', ...)`, `window.addEventListener('pushstate', ...)`, and `window.addEventListener('hashchange', ...)` did not trigger when I navigated to a new page.

The one of solutions that worked for me was to override the `history.pushState` function, but it has a downside: we can't get the title of the new page.

```javascript
history.pushState = function (state, unused, url) {
  _paq.push(["setCustomUrl", url]);
  _paq.push(["trackPageView"]);

  History.prototype.pushState.apply(history, arguments);
};
```

I solved it by observing the title changes.