### PR TITLE
Improve k8s docs

### DIFF
--- a/managed-kubernetes/expose-application-using-tls.mdx
+++ b/managed-kubernetes/expose-application-using-tls.mdx
@@ -77,6 +77,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: gateway
+  namespace: nginx-gateway
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
@@ -85,10 +86,16 @@ spec:
   - name: http
     port: 80
     protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
   - name: https
     hostname: "hello-world.$DOMAIN_SUFFIX"
     port: 443
     protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
     tls:
       mode: Terminate
       certificateRefs:
@@ -101,7 +108,7 @@ Once the Gateway is created, a Service named `gateway-nginx` will appear in the 
 
 You can see this service using the command below
 ```bash
-kubectl get service gateway-nginx
+kubectl -n nginx-gateway get service gateway-nginx
 ```
 
 Here's a sample output of the command:
@@ -109,15 +116,6 @@ Here's a sample output of the command:
 NAME            TYPE           CLUSTER-IP      EXTERNAL-IP                                  PORT(S)                      AGE
 gateway-nginx   LoadBalancer   10.105.61.236   devcluster-services-0b1c1.k8s.ubicloud.com   80:32271/TCP,443:30363/TCP   8m15s
 ```
-
-The `certificateRefs` field points to a Kubernetes Secret named `hello-world-tls` where the TLS certificate and private key will be stored. This Secret doesn't exist yet — cert-manager will create it in the next step.
-
-You can monitor the certificate status with:
-```bash
-kubectl get certificate hello-world-tls
-```
-
-Wait until the `READY` column shows `True` before proceeding.
 
 #### Deploy the application, Service, and HTTPRoute
 
@@ -162,6 +160,7 @@ metadata:
 spec:
   parentRefs:
   - name: gateway
+    namespace: nginx-gateway
     sectionName: https
   hostnames:
   - "hello-world.$DOMAIN_SUFFIX"

--- a/managed-kubernetes/expose-application-using-tls.mdx
+++ b/managed-kubernetes/expose-application-using-tls.mdx
@@ -25,7 +25,7 @@ export CLUSTER_ISSUER_EMAIL=email@yourcompany.com
 Next, we'll install the Gateway API CRDs, NGINX Gateway Fabric, and cert-manager.
 
 ```bash wrap
-kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2 | kubectl apply -f -
+kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.5.1 | kubectl apply -f -
 
 helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
   --create-namespace -n nginx-gateway

--- a/managed-kubernetes/expose-application-using-tls.mdx
+++ b/managed-kubernetes/expose-application-using-tls.mdx
@@ -24,15 +24,17 @@ export CLUSTER_ISSUER_EMAIL=email@yourcompany.com
 
 Next, we'll install the Gateway API CRDs, NGINX Gateway Fabric, and cert-manager.
 
-```bash
-kubectl kustomize "https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2" | kubectl apply -f -
+```bash wrap
+kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2 | kubectl apply -f -
 
-helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --create-namespace -n nginx-gateway
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace \
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
   --set crds.enabled=true \
   --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
   --set config.kind="ControllerConfiguration" \

--- a/managed-kubernetes/windmill-tutorial.mdx
+++ b/managed-kubernetes/windmill-tutorial.mdx
@@ -97,7 +97,7 @@ To expose Windmill securely via HTTPS, we'll employ NGINX Gateway Fabric, `cert-
 ### Installing NGINX Gateway Fabric & cert-manager
 Use the following commands to install the Gateway API CRDs, NGINX Gateway Fabric, and cert-manager:
 ```bash wrap
-kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2 | kubectl apply -f -
+kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.5.1 | kubectl apply -f -
 
 helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
   --create-namespace -n nginx-gateway

--- a/managed-kubernetes/windmill-tutorial.mdx
+++ b/managed-kubernetes/windmill-tutorial.mdx
@@ -38,12 +38,12 @@ kubectl create secret generic -n windmill pg-db-credentials \
 ## Deploying Windmill
 Add Windmill Helm repo:
 
-```bash
+```bash wrap
 helm repo add windmill https://windmill-labs.github.io/windmill-helm-charts/
 ```
 
 Download the `values.yaml` file for the Windmill chart:
-```bash
+```bash wrap
 curl -O https://raw.githubusercontent.com/windmill-labs/windmill-helm-charts/refs/heads/main/charts/windmill/values.yaml
 ```
 
@@ -85,14 +85,14 @@ kubectl -n windmill get service windmill-app
 
 ## Connecting to Windmill
 The application will be accessible via your cluster's load balancer URL at port 8000 a few minutes after the `EXTERNAL-IP` is assigned. Run the following command to retrieve the address for your Windmill deployment.
-```bash
+```bash wrap
 echo "http://$(kubectl -n windmill get service windmill-app --output jsonpath='{.status.loadBalancer.ingress[0].hostname}'):8000"
 ```
 
 Congratulations—Windmill is now running on Ubicloud!
 
 ## Configuring TLS for Secure Access
-To expose Windmill securely via HTTPS, we'll employ NGINX Gateway Fabric, `cert-manager`, and Let's Encrypt using the Kubernetes Gateway API.
+To expose Windmill securely via HTTPS, we'll employ Nginx Gateway Fabric, cert-manager, and Let's Encrypt using the Kubernetes Gateway API.
 
 ### Installing NGINX Gateway Fabric & cert-manager
 Use the following commands to install the Gateway API CRDs, NGINX Gateway Fabric, and cert-manager:
@@ -113,17 +113,19 @@ helm install cert-manager jetstack/cert-manager \
   --set config.enableGatewayAPI=true
 ```
 
-Next, create an issuer in the `windmill` namespace to obtain certificates from Let's Encrypt:
+Next, create a ClusterIssuer to obtain certificates from Let's Encrypt:
 ```bash
-kubectl apply -n windmill -f <(cat <<EOF
+export CLUSTER_ISSUER_EMAIL=email@yourcompany.com
+
+kubectl apply -f <(cat <<EOF
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
- name: letsencrypt-windmill
+ name: letsencrypt
 spec:
  acme:
    server: https://acme-v02.api.letsencrypt.org/directory
-   email: <YOUR E-MAIL ADDREESS>
+   email: $CLUSTER_ISSUER_EMAIL
    privateKeySecretRef:
      name: letsencrypt
    solvers:
@@ -137,20 +139,29 @@ EOF
 Create the Gateway resource. NGINX Gateway Fabric will automatically provision a `LoadBalancer` service and an NGINX data plane when a Gateway is created.
 
 ```bash
-kubectl apply -n windmill -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
   name: windmill-gateway
+  namespace: nginx-gateway
 spec:
   gatewayClassName: nginx
   listeners:
   - name: http
     port: 80
     protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
   - name: https
     port: 443
     protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
     tls:
       mode: Terminate
       certificateRefs:
@@ -161,7 +172,7 @@ EOF
 
 Once the Gateway is created, retrieve the external address of the LoadBalancer Service:
 ```bash
-kubectl -n windmill get service windmill-gateway-nginx
+kubectl -n nginx-gateway get service windmill-gateway-nginx
 ```
 
 You should get a result in the form `mycluster-services-0b1c1.k8s.ubicloud.com`. We will use this address in the following step to route traffic to the cluster securely.
@@ -193,23 +204,30 @@ Next, update the Gateway to include the hostname for the HTTPS listener, and cre
 ```bash
 export WINDMILL_DOMAIN=xxxxx-services-xxxxx.k8s.ubicloud.com # Replace with your service URL or domain
 
-kubectl apply -n windmill -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: windmill-gateway
+  namespace: nginx-gateway
   annotations:
-    cert-manager.io/issuer: letsencrypt-windmill
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   gatewayClassName: nginx
   listeners:
   - name: http
     port: 80
     protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
   - name: https
     hostname: "$WINDMILL_DOMAIN"
     port: 443
     protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
     tls:
       mode: Terminate
       certificateRefs:
@@ -220,9 +238,11 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: windmill
+  namespace: windmill
 spec:
   parentRefs:
   - name: windmill-gateway
+    namespace: nginx-gateway
     sectionName: https
   hostnames:
   - "$WINDMILL_DOMAIN"
@@ -234,6 +254,25 @@ spec:
     backendRefs:
     - name: windmill-app
       port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: windmill-redirect
+  namespace: windmill
+spec:
+  parentRefs:
+  - name: windmill-gateway
+    namespace: nginx-gateway
+    sectionName: http
+  hostnames:
+  - "$WINDMILL_DOMAIN"
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
 EOF
 ```
 
@@ -241,7 +280,7 @@ EOF
 
 Check the readiness of the TLS certificate for the Windmill application:
 ```bash
-kubectl -n windmill describe cert windmill-tls-cert
+kubectl -n nginx-gateway describe cert windmill-tls-cert
 ```
 
 Once the certificate is ready, you can access your Windmill application securely at https://xxxxx-services-xxxxx.k8s.ubicloud.com or https://windmill.yourdomain.com.

--- a/managed-kubernetes/windmill-tutorial.mdx
+++ b/managed-kubernetes/windmill-tutorial.mdx
@@ -57,7 +57,7 @@ Set the secret name for the database connection string:
 ```yaml
 windmill:
 ...
-  databaseUrlSecretName: "pg-db-credentials"
+  databaseUrlSecretName: pg-db-credentials
 ```
 
 Install the Windmill chart with the modified values.yaml file:
@@ -135,62 +135,31 @@ EOF
 )
 ```
 
-### Setting Up DNS Records for Traffic Routing
-Create the Gateway resource. NGINX Gateway Fabric will automatically provision a `LoadBalancer` service and an NGINX data plane when a Gateway is created.
+### Configuring HTTPS with Gateway API
 
-```bash
-kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-  name: windmill-gateway
-  namespace: nginx-gateway
-spec:
-  gatewayClassName: nginx
-  listeners:
-  - name: http
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: All
-  - name: https
-    port: 443
-    protocol: HTTPS
-    allowedRoutes:
-      namespaces:
-        from: All
-    tls:
-      mode: Terminate
-      certificateRefs:
-      - kind: Secret
-        name: windmill-tls-cert
-EOF
+To expose Windmill securely, you first need the external domain for your cluster. You can find this "Service URL" (e.g., `mycluster-services-0b1c1.k8s.ubicloud.com`) in the **Overview** page of your Kubernetes cluster in the Ubicloud console. Alternatively, you can use the address retrieved in the previous step:
+
+```bash wrap
+kubectl -n windmill get service windmill-app --output jsonpath='{.status.loadBalancer.ingress[0].hostname}'
 ```
 
-Once the Gateway is created, retrieve the external address of the LoadBalancer Service:
-```bash
-kubectl -n nginx-gateway get service windmill-gateway-nginx
-```
+<Note>If you prefer using a custom domain like `windmill.yourdomain.com`, create a `CNAME` record with your DNS provider pointing it to the Service URL mentioned above.</Note>
 
-You should get a result in the form `mycluster-services-0b1c1.k8s.ubicloud.com`. We will use this address in the following step to route traffic to the cluster securely.
+#### Updating Windmill Chart Values
+Update the domain values and disable the built-in ingress in `values.yaml`, as we will manage the Gateway API resources manually:
 
-<Note>If you want to use your domain such as `windmill.yourdomain.com`, create a CNAME record with your DNS provider to route `windmill.yourdomain.com` to the `EXTERNAL-IP` associated with the `windmill-gateway-nginx` service and use that address in the following steps.</Note>
-
-### Updating Windmill Chart Values and Creating Gateway Resources
-First, update the domain values and disable the built-in ingress in `values.yaml` since we'll use Gateway API resources directly:
 ```yaml
 windmill:
-  baseDomain: xxxxx-services-xxxxx.k8s.ubicloud.com # Replace with your service URL or domain
+  baseDomain: xxxxx-services-xxxxx.k8s.ubicloud.com # Replace with your Service URL or custom domain
   baseProtocol: https
 
 ingress:
   enabled: false
 ```
 
-Revert the service type back to `ClusterIP` since external access will now be handled by the Gateway:
+#### Reverting Service Type
+Since external traffic will now be handled by the Gateway, revert the `windmill-app` service back to `ClusterIP`:
+
 ```bash
 kubectl -n windmill patch svc windmill-app -p '{"spec": {"type": "ClusterIP"}}'
 ```
@@ -200,9 +169,11 @@ Apply the updated values to the Windmill installation:
 helm -n windmill upgrade my-windmill windmill/windmill -f values.yaml
 ```
 
-Next, update the Gateway to include the hostname for the HTTPS listener, and create the HTTPRoute to expose Windmill:
+#### Creating Gateway and HTTPRoute
+Finally, create the Gateway and HTTPRoute resources to expose Windmill via HTTPS:
+
 ```bash
-export WINDMILL_DOMAIN=xxxxx-services-xxxxx.k8s.ubicloud.com # Replace with your service URL or domain
+export WINDMILL_DOMAIN=xxxxx-services-xxxxx.k8s.ubicloud.com # Replace with your domain
 
 kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
@@ -277,8 +248,7 @@ EOF
 ```
 
 ### Verifying the Certificate Status
-
-Check the readiness of the TLS certificate for the Windmill application:
+It may take a few minutes for the certificate to be issued and the gateway to become fully operational. Check the readiness of the TLS certificate for the Windmill application:
 ```bash
 kubectl -n nginx-gateway describe cert windmill-tls-cert
 ```

--- a/managed-kubernetes/windmill-tutorial.mdx
+++ b/managed-kubernetes/windmill-tutorial.mdx
@@ -96,15 +96,17 @@ To expose Windmill securely via HTTPS, we'll employ NGINX Gateway Fabric, `cert-
 
 ### Installing NGINX Gateway Fabric & cert-manager
 Use the following commands to install the Gateway API CRDs, NGINX Gateway Fabric, and cert-manager:
-```bash
-kubectl kustomize "https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2" | kubectl apply -f -
+```bash wrap
+kubectl kustomize https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v2.4.2 | kubectl apply -f -
 
-helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
+helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --create-namespace -n nginx-gateway
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace \
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
   --set crds.enabled=true \
   --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
   --set config.kind="ControllerConfiguration" \


### PR DESCRIPTION
Add wrapping to improve readiblity in some code blocks

Bump NGINX Gateway Fabric to the latest version

Place the `Gateway` resource in the `nginx-gateway` instead of `default`. Since we have the one LoadBalancer per cluster limitation, it's best to place it in the same namespace as the ngf and allowing all namespaces to use it.